### PR TITLE
made generic between RPi and RPi2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
-wget http://archive.raspberrypi.org/debian/pool/main/r/raspi-config/raspi-config_20121028_all.deb
-wget http://ftp.acc.umu.se/mirror/cdimage/snapshot/Debian/pool/main/l/lua5.1/lua5.1_5.1.5-4_armel.deb
-wget http://http.us.debian.org/debian/pool/main/t/triggerhappy/triggerhappy_0.3.4-2_armel.deb
-dpkg -i triggerhappy_0.3.4-2_armel.deb
-dpkg -i lua5.1_5.1.5-4_armel.deb
+
+# must run as root or use sudo
+
+cd /tmp
+wget http://archive.raspberrypi.org/debian/pool/main/r/raspi-config/raspi-config_20150131-5_all.deb
+apt-get install libnewt0.52 whiptail parted triggerhappy lua5.1
 dpkg -i raspi-config_20121028_all.deb


### PR DESCRIPTION
Several other packages required to install raspi-config may not be on certain linux OSs (OSMC, in particular, although it probably isn't necessary on OSMC). Those missing packages were added.

Used apt-get to install packages, which makes it more generic (although it still requires apt). Main benefit of using apt-get is that it will automatically install packages for Raspberry Pi 2 architecture if necessary (armhf vice armel).

Also updated the raspi-config version to the most current.
